### PR TITLE
解决v2ray选用ss_tproxy分流不成功的BUG

### DIFF
--- a/script/sh_ss_tproxy.sh
+++ b/script/sh_ss_tproxy.sh
@@ -2475,7 +2475,7 @@ start() {
 	update_chnlist_ipset
 	update_check_file
 	
-	
+	update_dnsmasq_file #简单粗暴修复问题
 	
 	[ "$(type -t post_start)" != "" ] && post_start
 	delete_unused_iptchains


### PR DESCRIPTION
解决v2ray选用ss_tproxy分流通过自动脚本无法正常工作的问题（iptables不redirect任何数据包）
不知道为什么脚本跑完下来，"/tmp/ss_tproxy/dnsmasq.d"这个目录还是空的，但"/opt/app/ss_tproxy/dnsmasq.d"里有文件，所以简单粗暴地让它再update一下，同时完成重启dnsmasq的任务。