### PR TITLE
Allow port on ipv6 with ip6tables

### DIFF
--- a/script/Sh24_ssserver.sh
+++ b/script/Sh24_ssserver.sh
@@ -127,6 +127,8 @@ kill_ps "$scriptname keep"
 sed -Ei '/【SS_server】|^$/d' /tmp/script/_opt_script_check
 iptables -t filter -D INPUT -p tcp --dport $ssserver_port -j ACCEPT
 iptables -t filter -D INPUT -p udp --dport $ssserver_port -j ACCEPT
+ip6tables -t filter -D INPUT -p tcp --dport $ssserver_port -j ACCEPT
+ip6tables -t filter -D INPUT -p udp --dport $ssserver_port -j ACCEPT
 killall ss-server obfs-server gq-server
 killall -9 ss-server obfs-server gq-server
 ss_plugin_server_name="$(nvram get ss_plugin_server_name)"
@@ -297,6 +299,8 @@ if [ "$ssserver_enable" = "1" ] ; then
 		logger -t "【SS_server】" "允许 $ssserver_port 端口通过防火墙"
 		iptables -t filter -I INPUT -p tcp --dport $ssserver_port -j ACCEPT
 		iptables -t filter -I INPUT -p udp --dport $ssserver_port -j ACCEPT
+		ip6tables -t filter -I INPUT -p tcp --dport $ssserver_port -j ACCEPT
+		ip6tables -t filter -I INPUT -p udp --dport $ssserver_port -j ACCEPT
 	fi
 fi
 


### PR DESCRIPTION
实际使用时ss-server无法通过ipv6从外界访问，通过检查脚本发现脚本中仅使用了iptables开放端口，因此使用ip6tables开放相同的端口，亲测修改后ipv6外界可访问。