### PR TITLE
修复当DNS记录太多时，更新IPv6域名会因为AAAA记录获取不完整导致因添加重复域名而报错

### DIFF
--- a/script/Sh44_cloudflare.sh
+++ b/script/Sh44_cloudflare.sh
@@ -257,7 +257,7 @@ esac
 # 获得Zone_ID
 get_Zone_ID
 # 获得最后更新IP
-recordIP=$(curl -L    -s -X GET "https://api.cloudflare.com/client/v4/zones/$Zone_ID/dns_records" \
+recordIP=$(curl -L    -s -X GET "https://api.cloudflare.com/client/v4/zones/$Zone_ID/dns_records?type=$domain_type&match=all" \
      -H "Content-Type: application/json" \
      $account_key_a1 "$account_key_1" \
      $account_key_a2 "$account_key_2")


### PR DESCRIPTION
修复当DNS记录太多时，更新IPv6域名会因为AAAA记录获取不完整导致因添加重复域名而报错、疯狂更新、疯狂失败。添加一个GET请求参数，指定DNS记录类型获取有限的完整的DNS记录列表，在一定程度上修复这个BUG。（当然，如果确切知道domain_id就更好了，100%精准无误判。毕竟出现这个BUG是因为Cloudflare API还是对返回数据做了长度限制，目前暂时没有测试这个长度究竟有多短。。）